### PR TITLE
Update to lpeg-1.0.2

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,6 +1,10 @@
-HISTORY for LPeg 1.0
+HISTORY for LPeg 1.0.2
 
-* Changes from version 0.12 to 1.0
+* Changes from version 1.0.1 to 1.0.2
+  ---------------------------------
+  + some bugs fixed
+
+* Changes from version 0.12 to 1.0.1
   ---------------------------------
   + group "names" can be any Lua value
   + some bugs fixed

--- a/doc.css
+++ b/doc.css
@@ -1,0 +1,223 @@
+body { 
+    margin-left: 1em; 
+    margin-right: 1em; 
+    font-family: arial, helvetica, geneva, sans-serif;
+	background-color:#ffffff; margin:0px;
+}
+
+code {
+    font-family: "Andale Mono", monospace; 
+}
+
+tt {
+    font-family: "Andale Mono", monospace; 
+}
+
+body, td, th { font-size: 11pt; }
+
+h1, h2, h3, h4 { margin-left: 0em; }
+
+textarea, pre, tt { font-size:10pt; }
+body, td, th { color:#000000; }
+small { font-size:0.85em; }
+h1 { font-size:1.5em; }
+h2 { font-size:1.25em; }
+h3 { font-size:1.15em; }
+h4 { font-size:1.06em; }
+
+a:link { font-weight:bold; color: #004080; text-decoration: none; }
+a:visited { font-weight:bold; color: #006699; text-decoration: none; }
+a:link:hover { text-decoration:underline; }
+hr { color:#cccccc }
+img { border-width: 0px; }
+
+
+h3 { padding-top: 1em; }
+
+p { margin-left: 1em; }
+
+p.name { 
+    font-family: "Andale Mono", monospace; 
+    padding-top: 1em;
+    margin-left: 0em; 
+}
+
+blockquote { margin-left: 3em; }
+
+.example {
+    background-color: rgb(245, 245, 245);
+    border-top-width: 1px;
+    border-right-width: 1px;
+    border-bottom-width: 1px;
+    border-left-width: 1px;
+    border-top-style: solid;
+    border-right-style: solid;
+    border-bottom-style: solid;
+    border-left-style: solid;
+    border-top-color: silver;
+    border-right-color: silver;
+    border-bottom-color: silver;
+    border-left-color: silver;
+    padding: 1em;
+    margin-left: 1em;
+    margin-right: 1em;
+    font-family: "Andale Mono", monospace; 
+    font-size: smaller;
+}
+
+
+hr { 
+    margin-left: 0em;
+	background: #00007f; 
+	border: 0px;
+	height: 1px;
+}
+
+ul { list-style-type: disc; }
+
+table.index { border: 1px #00007f; }
+table.index td { text-align: left; vertical-align: top; }
+table.index ul { padding-top: 0em; margin-top: 0em; }
+
+table {
+    border: 1px solid black;
+	border-collapse: collapse;
+    margin-left: auto;
+    margin-right: auto;
+}
+th {
+    border: 1px solid black;
+    padding: 0.5em;
+}
+td {
+    border: 1px solid black;
+    padding: 0.5em;
+}
+div.header, div.footer { margin-left: 0em; }
+
+#container
+{
+	margin-left: 1em;
+	margin-right: 1em;
+	background-color: #f0f0f0;
+}
+
+#product
+{
+	text-align: center;
+	border-bottom: 1px solid #cccccc;
+	background-color: #ffffff;
+}
+
+#product big {
+	font-size: 2em;
+}
+
+#product_logo
+{
+}
+
+#product_name
+{
+}
+
+#product_description
+{
+}
+
+#main
+{
+	background-color: #f0f0f0;
+	border-left: 2px solid #cccccc;
+}
+
+#navigation
+{
+	float: left;
+	width: 12em;
+	margin: 0;
+	vertical-align: top;
+	background-color: #f0f0f0;
+	overflow:visible;
+}
+
+#navigation h1 {
+	background-color:#e7e7e7;
+	font-size:1.1em;
+	color:#000000;
+	text-align:left;
+	margin:0px;
+	padding:0.2em;
+	border-top:1px solid #dddddd;
+	border-bottom:1px solid #dddddd;
+}
+
+#navigation ul
+{
+	font-size:1em;
+	list-style-type: none;
+	padding: 0;
+	margin: 1px;
+}
+
+#navigation li
+{
+	text-indent: -1em;
+	margin: 0em 0em 0em 0.5em;
+	display: block;
+	padding: 3px 0px 0px 12px;
+}
+
+#navigation li li a
+{
+	padding: 0px 3px 0px -1em;
+}
+
+#content
+{
+	margin-left: 12em;
+	padding: 1em;
+	border-left: 2px solid #cccccc;
+	border-right: 2px solid #cccccc;
+	background-color: #ffffff;
+}
+
+#about
+{
+	clear: both;
+	margin: 0;
+	padding: 5px;
+	border-top: 2px solid #cccccc;
+	background-color: #ffffff;
+}
+
+@media print {
+	body { 
+		font: 10pt "Times New Roman", "TimeNR", Times, serif;
+	}
+	a { font-weight:bold; color: #004080; text-decoration: underline; }
+	
+	#main	{		background-color: #ffffff;		border-left: 0px;	}	
+	#container	{		margin-left: 2%;		margin-right: 2%;		background-color: #ffffff;	}
+	
+	#content	{		margin-left: 0px;		padding: 1em;		border-left: 0px;		border-right: 0px;		background-color: #ffffff;	}
+	
+	#navigation	{		display: none;
+	}
+	
+	#product_logo
+	{
+		display: none;
+	}
+
+	#about img
+	{
+		display: none;
+	}
+
+	.example {
+		font-family: "Andale Mono", monospace; 
+		font-size: 8pt;
+		page-break-inside: avoid;
+	}
+}

--- a/lpcap.c
+++ b/lpcap.c
@@ -271,15 +271,15 @@ int finddyncap (Capture *cap, Capture *last) {
 
 
 /*
-** Calls a runtime capture. Returns number of captures removed by
-** the call, including the initial Cgroup. (Captures to be added are
-** on the Lua stack.)
+** Calls a runtime capture. Returns number of captures "removed" by the
+** call, that is, those inside the group capture. Captures to be added
+** are on the Lua stack.
 */
 int runtimecap (CapState *cs, Capture *close, const char *s, int *rem) {
   int n, id;
   lua_State *L = cs->L;
   int otop = lua_gettop(L);
-  Capture *open = findopen(close);
+  Capture *open = findopen(close);  /* get open group capture */
   assert(captype(open) == Cgroup);
   id = finddyncap(open, close);  /* get first dynamic capture argument */
   close->kind = Cclose;  /* closes the group */
@@ -299,7 +299,7 @@ int runtimecap (CapState *cs, Capture *close, const char *s, int *rem) {
   }
   else
     *rem = 0;  /* no dynamic captures removed */
-  return close - open;  /* number of captures of all kinds removed */
+  return close - open - 1;  /* number of captures to be removed */
 }
 
 
@@ -441,70 +441,88 @@ static int addonestring (luaL_Buffer *b, CapState *cs, const char *what) {
 }
 
 
+#if !defined(MAXRECLEVEL)
+#define MAXRECLEVEL	200
+#endif
+
+
 /*
 ** Push all values of the current capture into the stack; returns
 ** number of values pushed
 */
 static int pushcapture (CapState *cs) {
   lua_State *L = cs->L;
+  int res;
   luaL_checkstack(L, 4, "too many captures");
+  if (cs->reclevel++ > MAXRECLEVEL)
+    return luaL_error(L, "subcapture nesting too deep");
   switch (captype(cs->cap)) {
     case Cposition: {
       lua_pushinteger(L, cs->cap->s - cs->s + 1);
       cs->cap++;
-      return 1;
+      res = 1;
+      break;
     }
     case Cconst: {
       pushluaval(cs);
       cs->cap++;
-      return 1;
+      res = 1;
+      break;
     }
     case Carg: {
       int arg = (cs->cap++)->idx;
       if (arg + FIXEDARGS > cs->ptop)
         return luaL_error(L, "reference to absent extra argument #%d", arg);
       lua_pushvalue(L, arg + FIXEDARGS);
-      return 1;
+      res = 1;
+      break;
     }
     case Csimple: {
       int k = pushnestedvalues(cs, 1);
       lua_insert(L, -k);  /* make whole match be first result */
-      return k;
+      res = k;
+      break;
     }
     case Cruntime: {
       lua_pushvalue(L, (cs->cap++)->idx);  /* value is in the stack */
-      return 1;
+      res = 1;
+      break;
     }
     case Cstring: {
       luaL_Buffer b;
       luaL_buffinit(L, &b);
       stringcap(&b, cs);
       luaL_pushresult(&b);
-      return 1;
+      res = 1;
+      break;
     }
     case Csubst: {
       luaL_Buffer b;
       luaL_buffinit(L, &b);
       substcap(&b, cs);
       luaL_pushresult(&b);
-      return 1;
+      res = 1;
+      break;
     }
     case Cgroup: {
       if (cs->cap->idx == 0)  /* anonymous group? */
-        return pushnestedvalues(cs, 0);  /* add all nested values */
+        res = pushnestedvalues(cs, 0);  /* add all nested values */
       else {  /* named group: add no values */
         nextcap(cs);  /* skip capture */
-        return 0;
+        res = 0;
       }
+      break;
     }
-    case Cbackref: return backrefcap(cs);
-    case Ctable: return tablecap(cs);
-    case Cfunction: return functioncap(cs);
-    case Cnum: return numcap(cs);
-    case Cquery: return querycap(cs);
-    case Cfold: return foldcap(cs);
-    default: assert(0); return 0;
+    case Cbackref: res = backrefcap(cs); break;
+    case Ctable: res = tablecap(cs); break;
+    case Cfunction: res = functioncap(cs); break;
+    case Cnum: res = numcap(cs); break;
+    case Cquery: res = querycap(cs); break;
+    case Cfold: res = foldcap(cs); break;
+    default: assert(0); res = 0;
   }
+  cs->reclevel--;
+  return res;
 }
 
 
@@ -521,7 +539,7 @@ int getcaptures (lua_State *L, const char *s, const char *r, int ptop) {
   int n = 0;
   if (!isclosecap(capture)) {  /* is there any capture? */
     CapState cs;
-    cs.ocap = cs.cap = capture; cs.L = L;
+    cs.ocap = cs.cap = capture; cs.L = L; cs.reclevel = 0;
     cs.s = s; cs.valuecached = 0; cs.ptop = ptop;
     do {  /* collect their values */
       n += pushcapture(&cs);

--- a/lpcap.h
+++ b/lpcap.h
@@ -11,8 +11,21 @@
 
 /* kinds of captures */
 typedef enum CapKind {
-  Cclose, Cposition, Cconst, Cbackref, Carg, Csimple, Ctable, Cfunction,
-  Cquery, Cstring, Cnum, Csubst, Cfold, Cruntime, Cgroup
+  Cclose,  /* not used in trees */
+  Cposition,
+  Cconst,  /* ktable[key] is Lua constant */
+  Cbackref,  /* ktable[key] is "name" of group to get capture */
+  Carg,  /* 'key' is arg's number */
+  Csimple,  /* next node is pattern */
+  Ctable,  /* next node is pattern */
+  Cfunction,  /* ktable[key] is function; next node is pattern */
+  Cquery,  /* ktable[key] is table; next node is pattern */
+  Cstring,  /* ktable[key] is string; next node is pattern */
+  Cnum,  /* numbered capture; 'key' is number of value to return */
+  Csubst,  /* substitution capture; next node is pattern */
+  Cfold,  /* ktable[key] is function; next node is pattern */
+  Cruntime,  /* not used in trees (is uses another type for tree) */
+  Cgroup  /* ktable[key] is group's "name" */
 } CapKind;
 
 
@@ -36,6 +49,7 @@ typedef struct CapState {
   int ptop;  /* index of last argument to 'match' */
   const char *s;  /* original string */
   int valuecached;  /* value stored in cache slot */
+  int reclevel;  /* recursion level */
 } CapState;
 
 

--- a/lpcode.h
+++ b/lpcode.h
@@ -13,7 +13,7 @@
 
 int tocharset (TTree *tree, Charset *cs);
 int checkaux (TTree *tree, int pred);
-int fixedlenx (TTree *tree, int count, int len);
+int fixedlen (TTree *tree);
 int hascaptures (TTree *tree);
 int hasleftrecursion (TTree *tree);
 int lp_gc (lua_State *L);
@@ -36,8 +36,6 @@ int sizei (const Instruction *i);
 ** something
 */
 #define nullable(t)	checkaux(t, PEnullable)
-
-#define fixedlen(t)     fixedlenx(t, 0, 0)
 
 
 

--- a/lpeg.html
+++ b/lpeg.html
@@ -22,7 +22,7 @@
   </div>
   <div id="product_name"><big><strong>LPeg</strong></big></div>
   <div id="product_description">
-     Parsing Expression Grammars For Lua, version 0.12
+     Parsing Expression Grammars For Lua, version 1.1
   </div>
 </div> <!-- id="product" -->
 
@@ -107,6 +107,9 @@ for creating patterns:
   <td>Matches any character in <code>string</code> (Set)</td></tr>
 <tr><td><a href="#op-r"><code>lpeg.R("<em>xy</em>")</code></a></td>
   <td>Matches any character between <em>x</em> and <em>y</em> (Range)</td></tr>
+<tr><td><a href="#op-utfR"><code>lpeg.utfR(cp1, cp2)</code></a></td>
+  <td>Matches an UTF-8 code point between <code>cp1</code> and
+  <code>cp2</code></td></tr>
 <tr><td><a href="#op-pow"><code>patt^n</code></a></td>
   <td>Matches at least <code>n</code> repetitions of <code>patt</code></td></tr>
 <tr><td><a href="#op-pow"><code>patt^-n</code></a></td>
@@ -142,7 +145,7 @@ so, it succeeds only at the end of the subject.
 LPeg also offers the <a href="re.html"><code>re</code> module</a>,
 which implements patterns following a regular-expression style
 (e.g., <code>[09]+</code>).
-(This module is 260 lines of Lua code,
+(This module is 270 lines of Lua code,
 and of course it uses LPeg to parse regular expressions and
 translate them to regular LPeg patterns.)
 </p>
@@ -164,7 +167,7 @@ or the <a href="#captures">captured values</a>
 <p>
 An optional numeric argument <code>init</code> makes the match
 start at that position in the subject string.
-As usual in Lua libraries,
+As in the Lua standard libraries,
 a negative value counts from the end.
 </p>
 
@@ -188,20 +191,23 @@ returns the string <code>"pattern"</code>.
 Otherwise returns nil.
 </p>
 
-<h3><a name="f-version"></a><code>lpeg.version ()</code></h3>
+<h3><a name="f-version"></a><code>lpeg.version</code></h3>
 <p>
-Returns a string with the running version of LPeg.
+A string (not a function) with the running version of LPeg.
 </p>
 
 <h3><a name="f-setstack"></a><code>lpeg.setmaxstack (max)</code></h3>
 <p>
-Sets the maximum size for the backtrack stack used by LPeg to
+Sets a limit for the size of the backtrack stack used by LPeg to
 track calls and choices.
+(The default limit is 400.)
 Most well-written patterns need little backtrack levels and
-therefore you seldom need to change this maximum;
-but a few useful patterns may need more space.
-Before changing this maximum you should try to rewrite your
+therefore you seldom need to change this limit;
+before changing it you should try to rewrite your
 pattern to avoid the need for extra space.
+Nevertheless, a few useful patterns may overflow.
+Also, with recursive grammars,
+subjects with deep recursion may also need larger limits.
 </p>
 
 
@@ -574,8 +580,9 @@ It is equivalent to the following grammar in standard PEG notation:
 <h2><a name="captures">Captures</a></h2>
 
 <p>
-A <em>capture</em> is a pattern that creates values
-(the so called <em>semantic information</em>) when it matches.
+A <em>capture</em> is a pattern that produces values
+(the so called <em>semantic information</em>)
+according to what it matches.
 LPeg offers several kinds of captures,
 which produces values based on matches and combine these values to
 produce new values.
@@ -629,10 +636,7 @@ or no value when <code>number</code> is zero.</td></tr>
 </tbody></table>
 
 <p>
-A capture pattern produces its values every time it succeeds.
-For instance,
-a capture inside a loop produces as many values as matched by the loop.
-A capture produces a value only when it succeeds.
+A capture pattern produces its values only when it succeeds.
 For instance,
 the pattern <code>lpeg.C(lpeg.P"a"^-1)</code>
 produces the empty string when there is no <code>"a"</code>
@@ -640,14 +644,20 @@ produces the empty string when there is no <code>"a"</code>
 while the pattern <code>lpeg.C("a")^-1</code>
 does not produce any value when there is no <code>"a"</code>
 (because the pattern <code>"a"</code> fails).
+A pattern inside a loop or inside a recursive structure
+produces values for each match.
 </p>
 
 <p>
 Usually,
-LPeg evaluates all captures only after (and if) the entire match succeeds.
-During <em>match time</em> it only gathers enough information
-to produce the capture values later.
-As a particularly important consequence,
+LPeg does not specify when (and if) it evaluates its captures.
+(As an example,
+consider the pattern <code>lpeg.P"a" / func / 0</code>.
+Because the "division" by 0 instructs LPeg to throw away the
+results from the pattern,
+LPeg may or may not call <code>func</code>.)
+Therefore, captures should avoid side effects.
+Moreover,
 most captures cannot affect the way a pattern matches a subject.
 The only exception to this rule is the
 so-called <a href="#matchtime"><em>match-time capture</em></a>.
@@ -682,7 +692,8 @@ argument given in the call to <code>lpeg.match</code>.
 Creates a <em>back capture</em>.
 This pattern matches the empty string and
 produces the values produced by the <em>most recent</em>
-<a href="#cap-g">group capture</a> named <code>name</code>.
+<a href="#cap-g">group capture</a> named <code>name</code>
+(where <code>name</code> can be any Lua value).
 </p>
 
 <p>
@@ -696,6 +707,12 @@ An <em>Outermost</em> capture means that the capture is not inside
 another complete capture.
 </p>
 
+<p>
+In the same way that LPeg does not specify when it evaluates captures,
+it does not specify whether it reuses
+values previously produced by the group
+or re-evaluates them.
+</p>
 
 <h3><a name="cap-cc"></a><code>lpeg.Cc ([value, ...])</code></h3>
 <p>
@@ -762,7 +779,8 @@ Creates a <em>group capture</em>.
 It groups all values returned by <code>patt</code>
 into a single capture.
 The group may be anonymous (if no name is given)
-or named with the given name.
+or named with the given name
+(which can be any non-nil Lua value).
 </p>
 
 <p>
@@ -801,7 +819,7 @@ all replacements.
 <h3><a name="cap-t"></a><code>lpeg.Ct (patt)</code></h3>
 <p>
 Creates a <em>table capture</em>.
-This capture creates a table and puts all values from all anonymous captures
+This capture returns a table with all values from all anonymous captures
 made by <code>patt</code> inside this table in successive integer keys,
 starting at 1.
 Moreover,
@@ -867,7 +885,8 @@ there is no captured value.
 <p>
 Creates a <em>match-time capture</em>.
 Unlike all other captures,
-this one is evaluated immediately when a match occurs.
+this one is evaluated immediately when a match occurs
+(even if it is part of a larger pattern that fails later).
 It forces the immediate evaluation of all its nested captures
 and then calls <code>function</code>.
 </p>
@@ -1375,13 +1394,20 @@ and the new term for each repetition.
 <h2><a name="download"></a>Download</h2>
 
 <p>LPeg 
-<a href="http://www.inf.puc-rio.br/~roberto/lpeg/lpeg-0.12.2.tar.gz">source code</a>.</p>
+<a href="http://www.inf.puc-rio.br/~roberto/lpeg/lpeg-1.0.2.tar.gz">source code</a>.</p>
+
+<p>
+Probably, the easiest way to install LPeg is with
+<a href="https://luarocks.org/">LuaRocks</a>.
+If you have LuaRocks installed,
+the following command is all you need to install LPeg:
+<pre>$ luarocks install lpeg</pre>
 
 
 <h2><a name="license">License</a></h2>
 
 <p>
-Copyright &copy; 2014 Lua.org, PUC-Rio.
+Copyright &copy; 2007-2019 Lua.org, PUC-Rio.
 </p>
 <p>
 Permission is hereby granted, free of charge,

--- a/lptree.h
+++ b/lptree.h
@@ -13,31 +13,40 @@
 ** types of trees
 */
 typedef enum TTag {
-  TChar = 0, TSet, TAny,  /* standard PEG elements */
-  TTrue, TFalse,
-  TRep,
-  TSeq, TChoice,
-  TNot, TAnd,
-  TCall,
-  TOpenCall,
-  TRule,  /* sib1 is rule's pattern, sib2 is 'next' rule */
-  TGrammar,  /* sib1 is initial (and first) rule */
-  TBehind,  /* match behind */
-  TCapture,  /* regular capture */
-  TRunTime  /* run-time capture */
+  TChar = 0,  /* 'n' = char */
+  TSet,  /* the set is stored in next CHARSETSIZE bytes */
+  TAny,
+  TTrue,
+  TFalse,
+  TUTFR,  /* range of UTF-8 codepoints; 'n' has initial codepoint;
+             'cap' has length; 'key' has first byte;
+             extra info is similar for end codepoint */
+  TRep,  /* 'sib1'* */
+  TSeq,  /* 'sib1' 'sib2' */
+  TChoice,  /* 'sib1' / 'sib2' */
+  TNot,  /* !'sib1' */
+  TAnd,  /* &'sib1' */
+  TCall,  /* ktable[key] is rule's key; 'sib2' is rule being called */
+  TOpenCall,  /* ktable[key] is rule's key */
+  TRule,  /* ktable[key] is rule's key (but key == 0 for unused rules);
+             'sib1' is rule's pattern pre-rule; 'sib2' is next rule;
+             extra info 'n' is rule's sequential number */
+  TXInfo,  /* extra info */
+  TGrammar,  /* 'sib1' is initial (and first) rule */
+  TBehind,  /* 'sib1' is pattern, 'n' is how much to go back */
+  TCapture,  /* captures: 'cap' is kind of capture (enum 'CapKind');
+                ktable[key] is Lua value associated with capture;
+                'sib1' is capture body */
+  TRunTime  /* run-time capture: 'key' is Lua function;
+               'sib1' is capture body */
 } TTag;
-
-/* number of siblings for each tree */
-extern const byte numsiblings[];
 
 
 /*
 ** Tree trees
-** The first sibling of a tree (if there is one) is immediately after
-** the tree.  A reference to a second sibling (ps) is its position
-** relative to the position of the tree itself.  A key in ktable
-** uses the (unique) address of the original tree that created that
-** entry. NULL means no data.
+** The first child of a tree (if there is one) is immediately after
+** the tree.  A reference to a second child (ps) is its position
+** relative to the position of the tree itself.
 */
 typedef struct TTree {
   byte tag;
@@ -45,7 +54,7 @@ typedef struct TTree {
   byte lr;
   unsigned short key;  /* key in ktable for Lua data (0 if no key) */
   union {
-    int ps;  /* occasional second sibling */
+    int ps;  /* occasional second child */
     int n;  /* occasional counter */
   } u;
 } TTree;
@@ -62,10 +71,10 @@ typedef struct Pattern {
 } Pattern;
 
 
-/* number of siblings for each tree */
+/* number of children for each tree */
 extern const byte numsiblings[];
 
-/* access to siblings */
+/* access to children */
 #define sib1(t)         ((t) + 1)
 #define sib2(t)         ((t) + (t)->u.ps)
 

--- a/lptypes.h
+++ b/lptypes.h
@@ -1,7 +1,7 @@
 /*
 ** $Id: lptypes.h,v 1.14 2015/09/28 17:17:41 roberto Exp $
 ** LPeg - PEG pattern matching for Lua
-** Copyright 2007-2015, Lua.org & PUC-Rio  (see 'lpeg.html' for license)
+** Copyright 2007-2019, Lua.org & PUC-Rio  (see 'lpeg.html' for license)
 ** written by Roberto Ierusalimschy
 */
 
@@ -9,17 +9,13 @@
 #define lptypes_h
 
 
-#if !defined(LPEG_DEBUG)
-#define NDEBUG
-#endif
-
 #include <assert.h>
 #include <limits.h>
 
 #include "lua.h"
 
 
-#define VERSION         "1.0.0"
+#define VERSION         "1.1.0 LR"
 
 
 #define PATTERN_T	"lpeg-pattern"
@@ -41,6 +37,8 @@
 #define luaL_setfuncs(L,f,n)	luaL_register(L,NULL,f)
 #define luaL_newlib(L,f)	luaL_register(L,"lpeg",f)
 
+typedef size_t lua_Unsigned;
+
 #endif
 
 
@@ -55,7 +53,7 @@
 #endif
 
 
-/* maximum number of rules in a grammar */
+/* maximum number of rules in a grammar (limited by 'unsigned short') */
 #if !defined(MAXRULES)
 #define MAXRULES        1000
 #endif

--- a/lpvm.h
+++ b/lpvm.h
@@ -17,6 +17,7 @@ typedef enum Opcode {
   ITestChar,  /* if char != aux, jump to 'offset' */
   ITestSet,  /* if char not in buff, jump to 'offset' */
   ISpan,  /* read a span of chars in buff */
+  IUTFR,  /* if codepoint not in range [offset, utf_to], fail */
   IBehind,  /* walk back 'aux' characters (fail if not possible) */
   IRet,  /* return from a rule */
   IEnd,  /* end of pattern */
@@ -26,14 +27,15 @@ typedef enum Opcode {
   IOpenCall,  /* call rule number 'key' (must be closed to a ICall) */
   ICommit,  /* pop choice and jump to 'offset' */
   IPartialCommit,  /* update top choice to current position and jump */
-  IBackCommit,  /* "fails" but jump to its own 'offset' */
+  IBackCommit,  /* backtrack like "fail" but jump to its own 'offset' */
   IFailTwice,  /* pop one choice and then fail */
   IFail,  /* go back to saved state on choice and jump to saved offset */
   IGiveup,  /* internal use */
   IFullCapture,  /* complete capture of last 'off' chars */
   IOpenCapture,  /* start a capture */
   ICloseCapture,
-  ICloseRunTime
+  ICloseRunTime,
+  IEmpty  /* to fill empty slots left by optimizations */
 } Opcode;
 
 
@@ -47,6 +49,10 @@ typedef union Instruction {
   int offset;
   byte buff[1];
 } Instruction;
+
+
+/* extract 24-bit value from an instruction */
+#define utf_to(inst)	(((inst)->i.key << 8) | (inst)->i.aux)
 
 
 void printpatt (Instruction *p, int n);

--- a/makefile
+++ b/makefile
@@ -29,11 +29,11 @@ FILES = lpvm.o lpcap.o lptree.o lpcode.o lpprint.o
 
 # For Linux
 linux:
-	make lpeg.so "DLLFLAGS = -shared -fPIC"
+	$(MAKE) lpeg.so "DLLFLAGS = -shared -fPIC"
 
 # For Mac OS
 macosx:
-	make lpeg.so "DLLFLAGS = -bundle -undefined dynamic_lookup"
+	$(MAKE) lpeg.so "DLLFLAGS = -bundle -undefined dynamic_lookup"
 
 lpeg.so: $(FILES)
 	env $(CC) $(DLLFLAGS) $(FILES) -o lpeg.so

--- a/re.html
+++ b/re.html
@@ -93,6 +93,8 @@ Constructions are listed in order of decreasing precedence.
 equivalent to <code>p / defs[name]</code></td></tr>
 <tr><td><code>p =&gt; name</code></td> <td>match-time capture
 equivalent to <code>lpeg.Cmt(p, defs[name])</code></td></tr>
+<tr><td><code>p ~&gt; name</code></td> <td>fold capture
+equivalent to <code>lpeg.Cf(p, defs[name])</code></td></tr>
 <tr><td><code>& p</code></td> <td>and predicate</td></tr>
 <tr><td><code>! p</code></td> <td>not predicate</td></tr>
 <tr><td><code>p1 p2</code></td> <td>concatenation</td></tr>
@@ -296,7 +298,7 @@ it would be useful if each table had
 a <code>tag</code> field telling what non terminal
 that table represents.
 We can add such a tag using
-<a href="lpeg.html/#cap-g">named group captures</a>:
+<a href="lpeg.html#cap-g">named group captures</a>:
 </p>
 <pre class="example">
 x = re.compile[[
@@ -406,7 +408,7 @@ of patterns accepted by <code>re</code>.
 p = [=[
 
 pattern         &lt;- exp !.
-exp             &lt;- S (alternative / grammar)
+exp             &lt;- S (grammar / alternative)
 
 alternative     &lt;- seq ('/' S seq)*
 seq             &lt;- prefix*
@@ -421,6 +423,7 @@ primary         &lt;- '(' exp ')' / string / class / defined
                  / '=' name
                  / '{}'
                  / '{~' exp '~}'
+                 / '{|' exp '|}'
                  / '{' exp '}'
                  / '.'
                  / name S !arrow
@@ -434,7 +437,7 @@ item            &lt;- defined / range / .
 range           &lt;- . '-' [^]]
 
 S               &lt;- (%s / '--' [^%nl]*)*   -- spaces and comments
-name            &lt;- [A-Za-z][A-Za-z0-9_]*
+name            &lt;- [A-Za-z_][A-Za-z0-9_]*
 arrow           &lt;- '&lt;-'
 num             &lt;- [0-9]+
 string          &lt;- '"' [^"]* '"' / "'" [^']* "'"
@@ -450,7 +453,7 @@ print(re.match(p, p))   -- a self description must match itself
 <h2><a name="license">License</a></h2>
 
 <p>
-Copyright &copy; 2008-2010 Lua.org, PUC-Rio.
+Copyright &copy; 2008-2015 Lua.org, PUC-Rio.
 </p>
 <p>
 Permission is hereby granted, free of charge,

--- a/re.lua
+++ b/re.lua
@@ -71,13 +71,6 @@ updatelocale()
 local I = m.P(function (s,i) print(i, s:sub(1, i-1)); return i end)
 
 
-local function getdef (id, defs)
-  local c = defs and defs[id]
-  if not c then error("undefined name: " .. id) end
-  return c
-end
-
-
 local function patt_error (s, i)
   local msg = (#s < i + 20) and s:sub(i)
                              or s:sub(i,i+20) .. "..."
@@ -116,6 +109,20 @@ name = m.C(name)
 -- a defined name only have meaning in a given environment
 local Def = name * m.Carg(1)
 
+
+local function getdef (id, defs)
+  local c = defs and defs[id]
+  if not c then error("undefined name: " .. id) end
+  return c
+end
+
+-- match a name and return a group of its corresponding definition
+-- and 'f' (to be folded in 'Suffix')
+local function defwithfunc (f)
+  return m.Cg(Def / getdef * m.Cc(f))
+end
+
+
 local num = m.C(m.R"09"^1) * S / tonumber
 
 local String = "'" * m.C((any - "'")^0) * "'" +
@@ -130,7 +137,7 @@ end
 
 local Range = m.Cs(any * (m.P"-"/"") * (any - "]")) / mm.R
 
-local item = defined + Range + m.C(any)
+local item = (defined + Range + m.C(any)) / m.P
 
 local Class =
     "["
@@ -176,9 +183,10 @@ local exp = m.P{ "Exp",
                     )
             + "->" * S * ( m.Cg((String + num) * m.Cc(mt.__div))
                          + m.P"{}" * m.Cc(nil, m.Ct)
-                         + m.Cg(Def / getdef * m.Cc(mt.__div))
+                         + defwithfunc(mt.__div)
                          )
-            + "=>" * S * m.Cg(Def / getdef * m.Cc(m.Cmt))
+            + "=>" * S * defwithfunc(m.Cmt)
+            + "~>" * S * defwithfunc(m.Cf)
             ) * S
           )^0, function (a,b,f) return f(a,b) end );
   Primary = "(" * m.V"Exp" * ")"

--- a/testlr.lua
+++ b/testlr.lua
@@ -1,5 +1,11 @@
+print(package.path, package.path)
+package.path = './?.lua;' .. package.path
+package.cpath = './?.so;' .. package.cpath
+
 local lpeg = require"lpeg"
 local re = require"re"
+
+print(lpeg.version)
 
 local m = lpeg
 
@@ -15,8 +21,8 @@ end
 
 print"Tests for LPeg left recursion"
 
-assert(type(m.version()) == "string")
-print("version " .. m.version())
+assert(type(m.version) == "string")
+print("version " .. m.version)
 
 
 --[[


### PR DESCRIPTION
Still there is several invalid memory accesses detected by `valgrind` (they were there before too) when moving the old captures in `doublecap`:
```
valgrind lua testlr.lua 
==25853== Memcheck, a memory error detector
==25853== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==25853== Using Valgrind-3.17.0 and LibVEX; rerun with -h for copyright info
==25853== Command: lua testlr.lua
==25853== 
local/lua-5.3.5/share/lua/5.3/?.lua;local/lua-5.3.5/share/lua/5.3/?/init.lua;local/lua-5.3.5/lib/lua/5.3/?.lua;local/lua-5.3.5/lib/lua/5.3/?/init.lua;./?.lua;./?/init.lua	local/lua-5.3.5/share/lua/5.3/?.lua;local/lua-5.3.5/share/lua/5.3/?/init.lua;local/lua-5.3.5/lib/lua/5.3/?.lua;local/lua-5.3.5/lib/lua/5.3/?/init.lua;./?.lua;./?/init.lua
LPeg 1.1.0 LR
Tests for LPeg left recursion
version LPeg 1.1.0 LR
==25853== Invalid read of size 8
==25853==    at 0x4C3CA1C: memmove (vg_replace_strmem.c:1289)
==25853==    by 0x604B7C5: growcap.part.0 (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x604BA01: addcapturesfromlambda (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x604C4F0: match (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x60506C9: lp_match (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x1138E6: luaD_precall (in local/lua-5.3.5/bin/lua)
==25853==    by 0x11ED54: luaV_execute (in local/lua-5.3.5/bin/lua)
==25853==    by 0x113B27: luaD_call (in local/lua-5.3.5/bin/lua)
==25853==    by 0x113B50: luaD_callnoyield (in local/lua-5.3.5/bin/lua)
==25853==    by 0x112F8E: luaD_rawrunprotected (in local/lua-5.3.5/bin/lua)
==25853==    by 0x113E9A: luaD_pcall (in local/lua-5.3.5/bin/lua)
==25853==    by 0x111329: lua_pcallk (in local/lua-5.3.5/bin/lua)
==25853==  Address 0x5ce0328 is 0 bytes after a block of size 552 alloc'd
==25853==    at 0x4C32E8B: malloc (vg_replace_malloc.c:379)
==25853==    by 0x4C37CAA: realloc (vg_replace_malloc.c:1192)
==25853==    by 0x1169F5: luaM_realloc_ (in local/lua-5.3.5/bin/lua)
==25853==    by 0x11652A: luaC_newobj (in local/lua-5.3.5/bin/lua)
==25853==    by 0x11B8B0: luaS_newudata (in local/lua-5.3.5/bin/lua)
==25853==    by 0x1117DD: lua_newuserdata (in local/lua-5.3.5/bin/lua)
==25853==    by 0x604BA3D: newcap.constprop.0 (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x604CBF5: match (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x60506C9: lp_match (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x1138E6: luaD_precall (in local/lua-5.3.5/bin/lua)
==25853==    by 0x11ED54: luaV_execute (in local/lua-5.3.5/bin/lua)
==25853==    by 0x113B27: luaD_call (in local/lua-5.3.5/bin/lua)
==25853== 
==25853== Invalid read of size 8
==25853==    at 0x4C3CA27: memmove (vg_replace_strmem.c:1289)
==25853==    by 0x604B7C5: growcap.part.0 (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x604BA01: addcapturesfromlambda (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x604C4F0: match (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x60506C9: lp_match (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x1138E6: luaD_precall (in local/lua-5.3.5/bin/lua)
==25853==    by 0x11ED54: luaV_execute (in local/lua-5.3.5/bin/lua)
==25853==    by 0x113B27: luaD_call (in local/lua-5.3.5/bin/lua)
==25853==    by 0x113B50: luaD_callnoyield (in local/lua-5.3.5/bin/lua)
==25853==    by 0x112F8E: luaD_rawrunprotected (in local/lua-5.3.5/bin/lua)
==25853==    by 0x113E9A: luaD_pcall (in local/lua-5.3.5/bin/lua)
==25853==    by 0x111329: lua_pcallk (in local/lua-5.3.5/bin/lua)
==25853==  Address 0x5ce0330 is 8 bytes after a block of size 552 alloc'd
==25853==    at 0x4C32E8B: malloc (vg_replace_malloc.c:379)
==25853==    by 0x4C37CAA: realloc (vg_replace_malloc.c:1192)
==25853==    by 0x1169F5: luaM_realloc_ (in local/lua-5.3.5/bin/lua)
==25853==    by 0x11652A: luaC_newobj (in local/lua-5.3.5/bin/lua)
==25853==    by 0x11B8B0: luaS_newudata (in local/lua-5.3.5/bin/lua)
==25853==    by 0x1117DD: lua_newuserdata (in local/lua-5.3.5/bin/lua)
==25853==    by 0x604BA3D: newcap.constprop.0 (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x604CBF5: match (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x60506C9: lp_match (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x1138E6: luaD_precall (in local/lua-5.3.5/bin/lua)
==25853==    by 0x11ED54: luaV_execute (in local/lua-5.3.5/bin/lua)
==25853==    by 0x113B27: luaD_call (in local/lua-5.3.5/bin/lua)
==25853== 
==25853== Invalid read of size 8
==25853==    at 0x4C3CA2F: memmove (vg_replace_strmem.c:1289)
==25853==    by 0x604B7C5: growcap.part.0 (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x604BA01: addcapturesfromlambda (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x604C4F0: match (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x60506C9: lp_match (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x1138E6: luaD_precall (in local/lua-5.3.5/bin/lua)
==25853==    by 0x11ED54: luaV_execute (in local/lua-5.3.5/bin/lua)
==25853==    by 0x113B27: luaD_call (in local/lua-5.3.5/bin/lua)
==25853==    by 0x113B50: luaD_callnoyield (in local/lua-5.3.5/bin/lua)
==25853==    by 0x112F8E: luaD_rawrunprotected (in local/lua-5.3.5/bin/lua)
==25853==    by 0x113E9A: luaD_pcall (in local/lua-5.3.5/bin/lua)
==25853==    by 0x111329: lua_pcallk (in local/lua-5.3.5/bin/lua)
==25853==  Address 0x5ce0338 is 16 bytes after a block of size 552 alloc'd
==25853==    at 0x4C32E8B: malloc (vg_replace_malloc.c:379)
==25853==    by 0x4C37CAA: realloc (vg_replace_malloc.c:1192)
==25853==    by 0x1169F5: luaM_realloc_ (in local/lua-5.3.5/bin/lua)
==25853==    by 0x11652A: luaC_newobj (in local/lua-5.3.5/bin/lua)
==25853==    by 0x11B8B0: luaS_newudata (in local/lua-5.3.5/bin/lua)
==25853==    by 0x1117DD: lua_newuserdata (in local/lua-5.3.5/bin/lua)
==25853==    by 0x604BA3D: newcap.constprop.0 (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x604CBF5: match (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x60506C9: lp_match (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x1138E6: luaD_precall (in local/lua-5.3.5/bin/lua)
==25853==    by 0x11ED54: luaV_execute (in local/lua-5.3.5/bin/lua)
==25853==    by 0x113B27: luaD_call (in local/lua-5.3.5/bin/lua)
==25853== 
==25853== Invalid read of size 8
==25853==    at 0x4C3CA37: memmove (vg_replace_strmem.c:1289)
==25853==    by 0x604B7C5: growcap.part.0 (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x604BA01: addcapturesfromlambda (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x604C4F0: match (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x60506C9: lp_match (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x1138E6: luaD_precall (in local/lua-5.3.5/bin/lua)
==25853==    by 0x11ED54: luaV_execute (in local/lua-5.3.5/bin/lua)
==25853==    by 0x113B27: luaD_call (in local/lua-5.3.5/bin/lua)
==25853==    by 0x113B50: luaD_callnoyield (in local/lua-5.3.5/bin/lua)
==25853==    by 0x112F8E: luaD_rawrunprotected (in local/lua-5.3.5/bin/lua)
==25853==    by 0x113E9A: luaD_pcall (in local/lua-5.3.5/bin/lua)
==25853==    by 0x111329: lua_pcallk (in local/lua-5.3.5/bin/lua)
==25853==  Address 0x5ce0340 is 16 bytes after a block of size 560 in arena "client"
==25853== 
==25853== Invalid read of size 8
==25853==    at 0x4C3CA1C: memmove (vg_replace_strmem.c:1289)
==25853==    by 0x604B7C5: growcap.part.0 (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x604BA01: addcapturesfromlambda (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x604C829: match (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x60506C9: lp_match (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x1138E6: luaD_precall (in local/lua-5.3.5/bin/lua)
==25853==    by 0x11ED54: luaV_execute (in local/lua-5.3.5/bin/lua)
==25853==    by 0x113B27: luaD_call (in local/lua-5.3.5/bin/lua)
==25853==    by 0x113B50: luaD_callnoyield (in local/lua-5.3.5/bin/lua)
==25853==    by 0x112F8E: luaD_rawrunprotected (in local/lua-5.3.5/bin/lua)
==25853==    by 0x113E9A: luaD_pcall (in local/lua-5.3.5/bin/lua)
==25853==    by 0x111329: lua_pcallk (in local/lua-5.3.5/bin/lua)
==25853==  Address 0x5ce1428 is 0 bytes after a block of size 552 alloc'd
==25853==    at 0x4C32E8B: malloc (vg_replace_malloc.c:379)
==25853==    by 0x4C37CAA: realloc (vg_replace_malloc.c:1192)
==25853==    by 0x1169F5: luaM_realloc_ (in local/lua-5.3.5/bin/lua)
==25853==    by 0x11652A: luaC_newobj (in local/lua-5.3.5/bin/lua)
==25853==    by 0x11B8B0: luaS_newudata (in local/lua-5.3.5/bin/lua)
==25853==    by 0x1117DD: lua_newuserdata (in local/lua-5.3.5/bin/lua)
==25853==    by 0x604BA3D: newcap.constprop.0 (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x604CBF5: match (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x60506C9: lp_match (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x1138E6: luaD_precall (in local/lua-5.3.5/bin/lua)
==25853==    by 0x11ED54: luaV_execute (in local/lua-5.3.5/bin/lua)
==25853==    by 0x113B27: luaD_call (in local/lua-5.3.5/bin/lua)
==25853== 
==25853== Invalid read of size 8
==25853==    at 0x4C3CA27: memmove (vg_replace_strmem.c:1289)
==25853==    by 0x604B7C5: growcap.part.0 (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x604BA01: addcapturesfromlambda (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x604C829: match (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x60506C9: lp_match (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x1138E6: luaD_precall (in local/lua-5.3.5/bin/lua)
==25853==    by 0x11ED54: luaV_execute (in local/lua-5.3.5/bin/lua)
==25853==    by 0x113B27: luaD_call (in local/lua-5.3.5/bin/lua)
==25853==    by 0x113B50: luaD_callnoyield (in local/lua-5.3.5/bin/lua)
==25853==    by 0x112F8E: luaD_rawrunprotected (in local/lua-5.3.5/bin/lua)
==25853==    by 0x113E9A: luaD_pcall (in local/lua-5.3.5/bin/lua)
==25853==    by 0x111329: lua_pcallk (in local/lua-5.3.5/bin/lua)
==25853==  Address 0x5ce1430 is 8 bytes after a block of size 552 alloc'd
==25853==    at 0x4C32E8B: malloc (vg_replace_malloc.c:379)
==25853==    by 0x4C37CAA: realloc (vg_replace_malloc.c:1192)
==25853==    by 0x1169F5: luaM_realloc_ (in local/lua-5.3.5/bin/lua)
==25853==    by 0x11652A: luaC_newobj (in local/lua-5.3.5/bin/lua)
==25853==    by 0x11B8B0: luaS_newudata (in local/lua-5.3.5/bin/lua)
==25853==    by 0x1117DD: lua_newuserdata (in local/lua-5.3.5/bin/lua)
==25853==    by 0x604BA3D: newcap.constprop.0 (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x604CBF5: match (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x60506C9: lp_match (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x1138E6: luaD_precall (in local/lua-5.3.5/bin/lua)
==25853==    by 0x11ED54: luaV_execute (in local/lua-5.3.5/bin/lua)
==25853==    by 0x113B27: luaD_call (in local/lua-5.3.5/bin/lua)
==25853== 
==25853== Invalid read of size 8
==25853==    at 0x4C3CA2F: memmove (vg_replace_strmem.c:1289)
==25853==    by 0x604B7C5: growcap.part.0 (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x604BA01: addcapturesfromlambda (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x604C829: match (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x60506C9: lp_match (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x1138E6: luaD_precall (in local/lua-5.3.5/bin/lua)
==25853==    by 0x11ED54: luaV_execute (in local/lua-5.3.5/bin/lua)
==25853==    by 0x113B27: luaD_call (in local/lua-5.3.5/bin/lua)
==25853==    by 0x113B50: luaD_callnoyield (in local/lua-5.3.5/bin/lua)
==25853==    by 0x112F8E: luaD_rawrunprotected (in local/lua-5.3.5/bin/lua)
==25853==    by 0x113E9A: luaD_pcall (in local/lua-5.3.5/bin/lua)
==25853==    by 0x111329: lua_pcallk (in local/lua-5.3.5/bin/lua)
==25853==  Address 0x5ce1438 is 16 bytes after a block of size 552 alloc'd
==25853==    at 0x4C32E8B: malloc (vg_replace_malloc.c:379)
==25853==    by 0x4C37CAA: realloc (vg_replace_malloc.c:1192)
==25853==    by 0x1169F5: luaM_realloc_ (in local/lua-5.3.5/bin/lua)
==25853==    by 0x11652A: luaC_newobj (in local/lua-5.3.5/bin/lua)
==25853==    by 0x11B8B0: luaS_newudata (in local/lua-5.3.5/bin/lua)
==25853==    by 0x1117DD: lua_newuserdata (in local/lua-5.3.5/bin/lua)
==25853==    by 0x604BA3D: newcap.constprop.0 (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x604CBF5: match (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x60506C9: lp_match (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x1138E6: luaD_precall (in local/lua-5.3.5/bin/lua)
==25853==    by 0x11ED54: luaV_execute (in local/lua-5.3.5/bin/lua)
==25853==    by 0x113B27: luaD_call (in local/lua-5.3.5/bin/lua)
==25853== 
==25853== Invalid read of size 8
==25853==    at 0x4C3CA37: memmove (vg_replace_strmem.c:1289)
==25853==    by 0x604B7C5: growcap.part.0 (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x604BA01: addcapturesfromlambda (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x604C829: match (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x60506C9: lp_match (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x1138E6: luaD_precall (in local/lua-5.3.5/bin/lua)
==25853==    by 0x11ED54: luaV_execute (in local/lua-5.3.5/bin/lua)
==25853==    by 0x113B27: luaD_call (in local/lua-5.3.5/bin/lua)
==25853==    by 0x113B50: luaD_callnoyield (in local/lua-5.3.5/bin/lua)
==25853==    by 0x112F8E: luaD_rawrunprotected (in local/lua-5.3.5/bin/lua)
==25853==    by 0x113E9A: luaD_pcall (in local/lua-5.3.5/bin/lua)
==25853==    by 0x111329: lua_pcallk (in local/lua-5.3.5/bin/lua)
==25853==  Address 0x5ce1440 is 16 bytes after a block of size 560 in arena "client"
==25853== 
==25853== Invalid read of size 8
==25853==    at 0x4C3CA76: memmove (vg_replace_strmem.c:1289)
==25853==    by 0x604B7C5: growcap.part.0 (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x604BA01: addcapturesfromlambda (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x604C4F0: match (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x60506C9: lp_match (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x1138E6: luaD_precall (in local/lua-5.3.5/bin/lua)
==25853==    by 0x11ED54: luaV_execute (in local/lua-5.3.5/bin/lua)
==25853==    by 0x113B27: luaD_call (in local/lua-5.3.5/bin/lua)
==25853==    by 0x113B50: luaD_callnoyield (in local/lua-5.3.5/bin/lua)
==25853==    by 0x112F8E: luaD_rawrunprotected (in local/lua-5.3.5/bin/lua)
==25853==    by 0x113E9A: luaD_pcall (in local/lua-5.3.5/bin/lua)
==25853==    by 0x111329: lua_pcallk (in local/lua-5.3.5/bin/lua)
==25853==  Address 0x5cdbd08 is 24 bytes after a block of size 64 in arena "client"
==25853== 
==25853== Invalid read of size 8
==25853==    at 0x4C3CBC8: memmove (vg_replace_strmem.c:1289)
==25853==    by 0x604B7C5: growcap.part.0 (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x604BA01: addcapturesfromlambda (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x604C829: match (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x60506C9: lp_match (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x1138E6: luaD_precall (in local/lua-5.3.5/bin/lua)
==25853==    by 0x11ED54: luaV_execute (in local/lua-5.3.5/bin/lua)
==25853==    by 0x113B27: luaD_call (in local/lua-5.3.5/bin/lua)
==25853==    by 0x113B50: luaD_callnoyield (in local/lua-5.3.5/bin/lua)
==25853==    by 0x112F8E: luaD_rawrunprotected (in local/lua-5.3.5/bin/lua)
==25853==    by 0x113E9A: luaD_pcall (in local/lua-5.3.5/bin/lua)
==25853==    by 0x111329: lua_pcallk (in local/lua-5.3.5/bin/lua)
==25853==  Address 0x5ce5c58 is 8 bytes before a block of size 1,512 alloc'd
==25853==    at 0x4C32E8B: malloc (vg_replace_malloc.c:379)
==25853==    by 0x4C37CAA: realloc (vg_replace_malloc.c:1192)
==25853==    by 0x1169F5: luaM_realloc_ (in local/lua-5.3.5/bin/lua)
==25853==    by 0x11652A: luaC_newobj (in local/lua-5.3.5/bin/lua)
==25853==    by 0x11B8B0: luaS_newudata (in local/lua-5.3.5/bin/lua)
==25853==    by 0x1117DD: lua_newuserdata (in local/lua-5.3.5/bin/lua)
==25853==    by 0x604B7B0: growcap.part.0 (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x604BA01: addcapturesfromlambda (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x604C829: match (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x60506C9: lp_match (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x1138E6: luaD_precall (in local/lua-5.3.5/bin/lua)
==25853==    by 0x11ED54: luaV_execute (in local/lua-5.3.5/bin/lua)
==25853== 
==25853== Invalid read of size 8
==25853==    at 0x4C3CBD0: memmove (vg_replace_strmem.c:1289)
==25853==    by 0x604B7C5: growcap.part.0 (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x604BA01: addcapturesfromlambda (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x604C829: match (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x60506C9: lp_match (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x1138E6: luaD_precall (in local/lua-5.3.5/bin/lua)
==25853==    by 0x11ED54: luaV_execute (in local/lua-5.3.5/bin/lua)
==25853==    by 0x113B27: luaD_call (in local/lua-5.3.5/bin/lua)
==25853==    by 0x113B50: luaD_callnoyield (in local/lua-5.3.5/bin/lua)
==25853==    by 0x112F8E: luaD_rawrunprotected (in local/lua-5.3.5/bin/lua)
==25853==    by 0x113E9A: luaD_pcall (in local/lua-5.3.5/bin/lua)
==25853==    by 0x111329: lua_pcallk (in local/lua-5.3.5/bin/lua)
==25853==  Address 0x5ce5c50 is 16 bytes before a block of size 1,512 alloc'd
==25853==    at 0x4C32E8B: malloc (vg_replace_malloc.c:379)
==25853==    by 0x4C37CAA: realloc (vg_replace_malloc.c:1192)
==25853==    by 0x1169F5: luaM_realloc_ (in local/lua-5.3.5/bin/lua)
==25853==    by 0x11652A: luaC_newobj (in local/lua-5.3.5/bin/lua)
==25853==    by 0x11B8B0: luaS_newudata (in local/lua-5.3.5/bin/lua)
==25853==    by 0x1117DD: lua_newuserdata (in local/lua-5.3.5/bin/lua)
==25853==    by 0x604B7B0: growcap.part.0 (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x604BA01: addcapturesfromlambda (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x604C829: match (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x60506C9: lp_match (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x1138E6: luaD_precall (in local/lua-5.3.5/bin/lua)
==25853==    by 0x11ED54: luaV_execute (in local/lua-5.3.5/bin/lua)
==25853== 
==25853== Invalid read of size 8
==25853==    at 0x4C3CBDB: memmove (vg_replace_strmem.c:1289)
==25853==    by 0x604B7C5: growcap.part.0 (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x604BA01: addcapturesfromlambda (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x604C829: match (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x60506C9: lp_match (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x1138E6: luaD_precall (in local/lua-5.3.5/bin/lua)
==25853==    by 0x11ED54: luaV_execute (in local/lua-5.3.5/bin/lua)
==25853==    by 0x113B27: luaD_call (in local/lua-5.3.5/bin/lua)
==25853==    by 0x113B50: luaD_callnoyield (in local/lua-5.3.5/bin/lua)
==25853==    by 0x112F8E: luaD_rawrunprotected (in local/lua-5.3.5/bin/lua)
==25853==    by 0x113E9A: luaD_pcall (in local/lua-5.3.5/bin/lua)
==25853==    by 0x111329: lua_pcallk (in local/lua-5.3.5/bin/lua)
==25853==  Address 0x5ce5c48 is 24 bytes before a block of size 1,512 alloc'd
==25853==    at 0x4C32E8B: malloc (vg_replace_malloc.c:379)
==25853==    by 0x4C37CAA: realloc (vg_replace_malloc.c:1192)
==25853==    by 0x1169F5: luaM_realloc_ (in local/lua-5.3.5/bin/lua)
==25853==    by 0x11652A: luaC_newobj (in local/lua-5.3.5/bin/lua)
==25853==    by 0x11B8B0: luaS_newudata (in local/lua-5.3.5/bin/lua)
==25853==    by 0x1117DD: lua_newuserdata (in local/lua-5.3.5/bin/lua)
==25853==    by 0x604B7B0: growcap.part.0 (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x604BA01: addcapturesfromlambda (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x604C829: match (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x60506C9: lp_match (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x1138E6: luaD_precall (in local/lua-5.3.5/bin/lua)
==25853==    by 0x11ED54: luaV_execute (in local/lua-5.3.5/bin/lua)
==25853== 
==25853== Invalid read of size 8
==25853==    at 0x4C3CBBC: memmove (vg_replace_strmem.c:1289)
==25853==    by 0x604B7C5: growcap.part.0 (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x604BA01: addcapturesfromlambda (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x604C829: match (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x60506C9: lp_match (in dev/lua/LPegLR/lpeg.so)
==25853==    by 0x1138E6: luaD_precall (in local/lua-5.3.5/bin/lua)
==25853==    by 0x11ED54: luaV_execute (in local/lua-5.3.5/bin/lua)
==25853==    by 0x113B27: luaD_call (in local/lua-5.3.5/bin/lua)
==25853==    by 0x113B50: luaD_callnoyield (in local/lua-5.3.5/bin/lua)
==25853==    by 0x112F8E: luaD_rawrunprotected (in local/lua-5.3.5/bin/lua)
==25853==    by 0x113E9A: luaD_pcall (in local/lua-5.3.5/bin/lua)
==25853==    by 0x111329: lua_pcallk (in local/lua-5.3.5/bin/lua)
==25853==  Address 0x5ce5c40 is 32 bytes before a block of size 1,520 in arena "client"
==25853== 
OK
==25853== 
==25853== HEAP SUMMARY:
==25853==     in use at exit: 0 bytes in 0 blocks
==25853==   total heap usage: 4,489 allocs, 4,489 frees, 840,287 bytes allocated
==25853== 
==25853== All heap blocks were freed -- no leaks are possible
==25853== 
==25853== For lists of detected and suppressed errors, rerun with: -s
==25853== ERROR SUMMARY: 72 errors from 13 contexts (suppressed: 0 from 0)
```
